### PR TITLE
Add native-image.properties

### DIFF
--- a/mongo-reactive/src/main/resources/META-INF/native-image/io.micronaut.configuration.mongo.reactive.test/mongo-reactive/native-image.properties
+++ b/mongo-reactive/src/main/resources/META-INF/native-image/io.micronaut.configuration.mongo.reactive.test/mongo-reactive/native-image.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2017-2019 original authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Args = --initialize-at-run-time=io.micronaut.configuration.mongo.reactive.test.AbstractMongoProcessFactory


### PR DESCRIPTION
Add native-image.properties that defers the AbstractMongoProcessFactory class inicialization to run-time.

if it's in the confing under `META-INF` it's collected automatically by the native-iamag build -> no need for explicit args for the native build each time