### PR TITLE
Fix broken link for DefaultReactiveMongoConfiguration class.

### DIFF
--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -14,7 +14,7 @@ mongodb:
 
 See the API for api:configuration.mongo.reactive.DefaultMongoConfiguration[] for more information on the available configuration options.
 
-For the Reactive driver, the api:configuration.mongo.reactive.ReactiveMongoConfiguration[] exposes options to configure the Reactive Streams driver. For example:
+For the Reactive driver, the api:configuration.mongo.reactive.DefaultReactiveMongoConfiguration[] exposes options to configure the Reactive Streams driver. For example:
 
 
 .Configuring the Reactive Streams Driver


### PR DESCRIPTION
The link points out to ReactiveMongoConfiguration which doesn't exist in package. Right class may be DefaultReactiveMongoConfiguration