### PR TITLE
Fix codecs for Enum types not overriding default EnumCodec

### DIFF
--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
@@ -46,7 +46,6 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
     @Override
     public CodecRegistry build(AbstractMongoConfiguration configuration) {
         List<CodecRegistry> codecRegistries = new ArrayList<>();
-        codecRegistries.add(MongoClientSettings.getDefaultCodecRegistry());
 
         List<CodecRegistry> configuredCodecRegistries = configuration.getCodecRegistries();
         if (configuredCodecRegistries != null) {
@@ -56,6 +55,8 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
         if (codecList != null) {
             codecRegistries.add(fromCodecs(codecList));
         }
+
+        codecRegistries.add(MongoClientSettings.getDefaultCodecRegistry());
 
         final PojoCodecProvider.Builder builder = PojoCodecProvider.builder();
 


### PR DESCRIPTION
After updating Micronaut I was having this strange issue where my codec for an enum type was not working and instead the default EnumCodec was being used. What happened is that in MongoDB Java 4.5 they introduced a default codec for enums that happens to get applied before any codecs of your own in Micronaut due to the order of the codecs Micronaut passes them to the codecRegistries. Adding the default codec registries after the custom codec registries fixed the problem.