### PR TITLE
Revert mongo driver to 4.9.1 since 4.10.0 introduced serialization issues

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ groovy = "4.0.11"
 spock = "2.3-groovy-4.0"
 testcontainers = "1.18.3"
 
-managed-mongo = "4.10.0"
-managed-mongo-reactive = "4.10.0"
+managed-mongo = "4.9.1"
+managed-mongo-reactive = "4.9.1"
 
 micronaut-micrometer = "5.0.0-M5"
 micronaut-serde = "2.0.0-M12"


### PR DESCRIPTION
Reported issue to MongoDB here: https://jira.mongodb.org/browse/JAVA-5035
Meanwhile we will revert to the version that doesn't have issues.