### PR TITLE
Delay Mongo client shutdown during graceful shutdown

### DIFF
--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
@@ -321,7 +321,7 @@ public abstract class AbstractMongoConfiguration {
      */
     public void setShutdownDelay(Duration shutdownDelay) {
         if (shutdownDelay != null) {
-            this.shutdownDelay = shutdownDelay;
+            this.shutdownDelay = shutdownDelay.isNegative() ? Duration.ZERO : shutdownDelay;
         }
     }
 

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
@@ -31,6 +31,8 @@ import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 
 import jakarta.validation.constraints.NotBlank;
+
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -55,6 +57,7 @@ public abstract class AbstractMongoConfiguration {
     private boolean automaticClassModels = true;
     private CodecRegistryBuilder codecRegistryBuilder;
     private boolean useSerde;
+    private Duration shutdownDelay = Duration.ZERO;
 
     /**
      * Constructor.
@@ -302,6 +305,24 @@ public abstract class AbstractMongoConfiguration {
      */
     public boolean isUseSerde() {
         return useSerde;
+    }
+
+    /**
+     * @return The delay to wait before closing the Mongo client during shutdown.
+     */
+    public Duration getShutdownDelay() {
+        return shutdownDelay;
+    }
+
+    /**
+     * Sets the delay to wait before closing the Mongo client during shutdown.
+     *
+     * @param shutdownDelay The shutdown delay
+     */
+    public void setShutdownDelay(Duration shutdownDelay) {
+        if (shutdownDelay != null) {
+            this.shutdownDelay = shutdownDelay;
+        }
     }
 
     /**

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientCloser.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientCloser.java
@@ -26,6 +26,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tracks Mongo clients and delays bean destruction during Micronaut graceful shutdown.
@@ -69,17 +70,14 @@ public final class MongoClientCloser implements GracefulShutdownCapable {
     @Override
     public CompletionStage<?> shutdownGracefully() {
         Duration shutdownDelay = maxShutdownDelay();
-        if (shutdownDelay.isZero()) {
+        long shutdownDelayMillis = toMillisSaturated(shutdownDelay);
+        if (shutdownDelayMillis == 0) {
             return CompletableFuture.completedFuture(null);
         }
-        return CompletableFuture.runAsync(() -> {
-            try {
-                Thread.sleep(shutdownDelay.toMillis());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                LOG.warn("Interrupted while delaying Mongo client shutdown", e);
-            }
-        });
+        return CompletableFuture.runAsync(
+            () -> { },
+            CompletableFuture.delayedExecutor(shutdownDelayMillis, TimeUnit.MILLISECONDS)
+        );
     }
 
     private Duration maxShutdownDelay() {
@@ -87,6 +85,15 @@ public final class MongoClientCloser implements GracefulShutdownCapable {
             return shutdownDelays.values().stream()
                 .max(Duration::compareTo)
                 .orElse(Duration.ZERO);
+        }
+    }
+
+    private long toMillisSaturated(Duration shutdownDelay) {
+        try {
+            return shutdownDelay.toMillis();
+        } catch (ArithmeticException e) {
+            LOG.warn("Mongo shutdown delay {} exceeds the supported millisecond range; clamping to Long.MAX_VALUE", shutdownDelay);
+            return Long.MAX_VALUE;
         }
     }
 }

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientCloser.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientCloser.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.core;
+
+import io.micronaut.runtime.graceful.GracefulShutdownCapable;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Tracks Mongo clients and delays bean destruction during Micronaut graceful shutdown.
+ *
+ * @author graemerocher
+ * @since 6.0.0
+ */
+@Singleton
+public final class MongoClientCloser implements GracefulShutdownCapable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoClientCloser.class);
+
+    private final Map<Object, Duration> shutdownDelays = Collections.synchronizedMap(new IdentityHashMap<>());
+
+    /**
+     * Track a client with its configured shutdown delay.
+     *
+     * @param client The client
+     * @param shutdownDelay The shutdown delay
+     * @param <T> The mongo client type
+     * @return The client
+     */
+    public <T> T track(T client, Duration shutdownDelay) {
+        if (client != null && shutdownDelay != null && !shutdownDelay.isNegative() && !shutdownDelay.isZero()) {
+            shutdownDelays.put(client, shutdownDelay);
+        }
+        return client;
+    }
+
+    /**
+     * Stop tracking a client once bean destruction completes.
+     *
+     * @param client The client
+     */
+    public void untrack(Object client) {
+        if (client != null) {
+            shutdownDelays.remove(client);
+        }
+    }
+
+    @Override
+    public CompletionStage<?> shutdownGracefully() {
+        Duration shutdownDelay = maxShutdownDelay();
+        if (shutdownDelay.isZero()) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return CompletableFuture.runAsync(() -> {
+            try {
+                Thread.sleep(shutdownDelay.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                LOG.warn("Interrupted while delaying Mongo client shutdown", e);
+            }
+        });
+    }
+
+    private Duration maxShutdownDelay() {
+        synchronized (shutdownDelays) {
+            return shutdownDelays.values().stream()
+                .max(Duration::compareTo)
+                .orElse(Duration.ZERO);
+        }
+    }
+}

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoSettings.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoSettings.java
@@ -45,6 +45,10 @@ public interface MongoSettings {
      */
     String MONGODB_SERVERS = PREFIX + ".servers";
     /**
+     * The MongoDB shutdown delay setting.
+     */
+    String SHUTDOWN_DELAY = PREFIX + ".shutdown-delay";
+    /**
      * The default URI.
      */
     String DEFAULT_URI = "mongodb://localhost";

--- a/mongo-core/src/test/groovy/io/micronaut/configuration/mongo/core/MongoClientCloserSpec.groovy
+++ b/mongo-core/src/test/groovy/io/micronaut/configuration/mongo/core/MongoClientCloserSpec.groovy
@@ -49,9 +49,13 @@ class MongoClientCloserSpec extends Specification {
         long finalShutdownElapsed = System.nanoTime() - finalShutdownStarted
 
         then:
-        Duration.ofNanos(firstShutdownElapsed).toMillis() >= 150
-        Duration.ofNanos(secondShutdownElapsed).toMillis() >= 80
-        Duration.ofNanos(secondShutdownElapsed).toMillis() < 180
-        Duration.ofNanos(finalShutdownElapsed).toMillis() < 80
+        long firstShutdownMillis = Duration.ofNanos(firstShutdownElapsed).toMillis()
+        long secondShutdownMillis = Duration.ofNanos(secondShutdownElapsed).toMillis()
+        long finalShutdownMillis = Duration.ofNanos(finalShutdownElapsed).toMillis()
+
+        firstShutdownMillis >= 150
+        secondShutdownMillis >= 80
+        firstShutdownMillis >= secondShutdownMillis
+        finalShutdownMillis < 1000
     }
 }

--- a/mongo-core/src/test/groovy/io/micronaut/configuration/mongo/core/MongoClientCloserSpec.groovy
+++ b/mongo-core/src/test/groovy/io/micronaut/configuration/mongo/core/MongoClientCloserSpec.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.core
+
+import spock.lang.Specification
+
+import java.time.Duration
+
+class MongoClientCloserSpec extends Specification {
+
+    void "graceful shutdown waits for the longest tracked delay"() {
+        given:
+        MongoClientCloser mongoClientCloser = new MongoClientCloser()
+        Object shortDelayClient = new Object()
+        Object longDelayClient = new Object()
+        mongoClientCloser.track(shortDelayClient, Duration.ofMillis(100))
+        mongoClientCloser.track(longDelayClient, Duration.ofMillis(200))
+
+        when:
+        long firstShutdownStarted = System.nanoTime()
+        mongoClientCloser.shutdownGracefully().toCompletableFuture().join()
+        long firstShutdownElapsed = System.nanoTime() - firstShutdownStarted
+
+        and:
+        mongoClientCloser.untrack(longDelayClient)
+
+        long secondShutdownStarted = System.nanoTime()
+        mongoClientCloser.shutdownGracefully().toCompletableFuture().join()
+        long secondShutdownElapsed = System.nanoTime() - secondShutdownStarted
+
+        and:
+        mongoClientCloser.untrack(shortDelayClient)
+
+        long finalShutdownStarted = System.nanoTime()
+        mongoClientCloser.shutdownGracefully().toCompletableFuture().join()
+        long finalShutdownElapsed = System.nanoTime() - finalShutdownStarted
+
+        then:
+        Duration.ofNanos(firstShutdownElapsed).toMillis() >= 150
+        Duration.ofNanos(secondShutdownElapsed).toMillis() >= 80
+        Duration.ofNanos(secondShutdownElapsed).toMillis() < 180
+        Duration.ofNanos(finalShutdownElapsed).toMillis() < 80
+    }
+}

--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/DefaultReactiveMongoClientFactory.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/DefaultReactiveMongoClientFactory.java
@@ -18,6 +18,7 @@ package io.micronaut.configuration.mongo.reactive;
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
 import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration;
+import io.micronaut.configuration.mongo.core.MongoClientCloser;
 import io.micronaut.configuration.mongo.core.MongoSettings;
 import io.micronaut.context.annotation.Bean;
 import io.micronaut.context.annotation.Factory;
@@ -35,6 +36,14 @@ import io.micronaut.runtime.context.scope.Refreshable;
 @Factory
 public class DefaultReactiveMongoClientFactory {
 
+    private final MongoClientCloser mongoClientCloser;
+
+    /**
+     * @param mongoClientCloser Tracks configured shutdown delays
+     */
+    public DefaultReactiveMongoClientFactory(MongoClientCloser mongoClientCloser) {
+        this.mongoClientCloser = mongoClientCloser;
+    }
 
     /**
      * Factory Method for creating a client.
@@ -45,6 +54,9 @@ public class DefaultReactiveMongoClientFactory {
     @Refreshable(MongoSettings.PREFIX)
     @Primary
     MongoClient mongoClient(DefaultMongoConfiguration mongoConfiguration) {
-        return MongoClients.create(mongoConfiguration.buildSettings());
+        return mongoClientCloser.track(
+            MongoClients.create(mongoConfiguration.buildSettings()),
+            mongoConfiguration.getShutdownDelay()
+        );
     }
 }

--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/MongoClientShutdownListener.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/MongoClientShutdownListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.reactive;
+
+import com.mongodb.reactivestreams.client.MongoClient;
+import io.micronaut.configuration.mongo.core.MongoClientCloser;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.core.annotation.Internal;
+import jakarta.inject.Singleton;
+
+/**
+ * Cleans up tracked reactive Mongo clients when beans are destroyed.
+ *
+ * @author graemerocher
+ * @since 6.0.0
+ */
+@Internal
+@Requires(classes = MongoClient.class)
+@Singleton
+final class MongoClientShutdownListener implements BeanDestroyedEventListener<MongoClient> {
+
+    private final MongoClientCloser mongoClientCloser;
+
+    /**
+     * @param mongoClientCloser Tracks configured shutdown delays
+     */
+    MongoClientShutdownListener(MongoClientCloser mongoClientCloser) {
+        this.mongoClientCloser = mongoClientCloser;
+    }
+
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<MongoClient> event) {
+        mongoClientCloser.untrack(event.getBean());
+    }
+}

--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/MongoClientShutdownListener.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/MongoClientShutdownListener.java
@@ -24,7 +24,7 @@ import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
 /**
- * Cleans up tracked reactive Mongo clients when beans are destroyed.
+ * Untracks reactive Mongo clients when beans are destroyed.
  *
  * @author graemerocher
  * @since 6.0.0

--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/NamedReactiveMongoClientFactory.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/NamedReactiveMongoClientFactory.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.mongo.reactive;
 
 import com.mongodb.reactivestreams.client.MongoClient;
 import com.mongodb.reactivestreams.client.MongoClients;
+import io.micronaut.configuration.mongo.core.MongoClientCloser;
 import io.micronaut.configuration.mongo.core.MongoSettings;
 import io.micronaut.configuration.mongo.core.NamedMongoConfiguration;
 import io.micronaut.context.annotation.Bean;
@@ -33,6 +34,15 @@ import io.micronaut.runtime.context.scope.Refreshable;
 @Factory
 public class NamedReactiveMongoClientFactory {
 
+    private final MongoClientCloser mongoClientCloser;
+
+    /**
+     * @param mongoClientCloser Tracks configured shutdown delays
+     */
+    public NamedReactiveMongoClientFactory(MongoClientCloser mongoClientCloser) {
+        this.mongoClientCloser = mongoClientCloser;
+    }
+
     /**
      * Factory name to create a client.
      * @param configuration configuration pulled in
@@ -42,6 +52,9 @@ public class NamedReactiveMongoClientFactory {
     @EachBean(NamedMongoConfiguration.class)
     @Refreshable(MongoSettings.PREFIX)
     MongoClient mongoClient(NamedMongoConfiguration configuration) {
-        return MongoClients.create(configuration.buildSettings());
+        return mongoClientCloser.track(
+            MongoClients.create(configuration.buildSettings()),
+            configuration.getShutdownDelay()
+        );
     }
 }

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
@@ -33,8 +33,7 @@ import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.qualifiers.Qualifiers
-import io.micronaut.runtime.event.ApplicationShutdownEvent
-import io.micronaut.runtime.event.annotation.EventListener
+import io.micronaut.runtime.graceful.GracefulShutdownCapable
 import jakarta.inject.Singleton
 import org.bson.BsonReader
 import org.bson.BsonWriter
@@ -53,6 +52,8 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -376,7 +377,7 @@ class MongoReactiveConfigurationSpec extends Specification {
 
     @Singleton
     @Requires(property = 'spec.name', value = 'shutdown-delay-reactive')
-    static class ReactiveShutdownListener {
+    static class ReactiveShutdownListener implements GracefulShutdownCapable {
 
         final MongoClient mongoClient
         final CountDownLatch completed = new CountDownLatch(1)
@@ -386,8 +387,8 @@ class MongoReactiveConfigurationSpec extends Specification {
             this.mongoClient = mongoClient
         }
 
-        @EventListener
-        void onShutdown(ApplicationShutdownEvent event) {
+        @Override
+        CompletionStage<?> shutdownGracefully() {
             try {
                 Mono.from(
                         mongoClient.getDatabase('shutdown-delay')
@@ -399,6 +400,7 @@ class MongoReactiveConfigurationSpec extends Specification {
             } finally {
                 completed.countDown()
             }
+            return CompletableFuture.completedFuture(null)
         }
     }
 }

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
@@ -388,18 +388,16 @@ class MongoReactiveConfigurationSpec extends Specification {
 
         @EventListener
         void onShutdown(ApplicationShutdownEvent event) {
-            Thread.start {
-                try {
-                    Mono.from(
-                            mongoClient.getDatabase('shutdown-delay')
-                                    .getCollection('reactive-events')
-                                    .insertOne(new Document('marker', 'reactive'))
-                    ).block()
-                } catch (Throwable e) {
-                    error = e
-                } finally {
-                    completed.countDown()
-                }
+            try {
+                Mono.from(
+                        mongoClient.getDatabase('shutdown-delay')
+                                .getCollection('reactive-events')
+                                .insertOne(new Document('marker', 'reactive'))
+                ).block()
+            } catch (Throwable e) {
+                error = e
+            } finally {
+                completed.countDown()
             }
         }
     }

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
@@ -303,9 +303,9 @@ class MongoReactiveConfigurationSpec extends Specification {
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': 'shutdown-delay-reactive',
                 (MongoSettings.MONGODB_URI): uri,
-                'mongodb.shutdown-delay': '1s',
+                'mongodb.shutdown-delay': '5s',
                 'micronaut.lifecycle.graceful-shutdown.enabled': true,
-                'micronaut.lifecycle.graceful-shutdown.grace-period': '5s'
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '10s'
         ])
         ReactiveShutdownListener listener = context.getBean(ReactiveShutdownListener)
         MongoClient verificationClient = MongoClients.create(uri)
@@ -390,7 +390,6 @@ class MongoReactiveConfigurationSpec extends Specification {
         void onShutdown(ApplicationShutdownEvent event) {
             Thread.start {
                 try {
-                    Thread.sleep(250)
                     Mono.from(
                             mongoClient.getDatabase('shutdown-delay')
                                     .getCollection('reactive-events')

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
@@ -53,7 +53,6 @@ import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
 
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -315,7 +314,7 @@ class MongoReactiveConfigurationSpec extends Specification {
         context.stop()
 
         then:
-        listener.completed.await(5, TimeUnit.SECONDS)
+        listener.completed.await(15, TimeUnit.SECONDS)
         listener.error == null
         Mono.from(
                 verificationClient.getDatabase('shutdown-delay').getCollection('reactive-events')
@@ -389,7 +388,7 @@ class MongoReactiveConfigurationSpec extends Specification {
 
         @EventListener
         void onShutdown(ApplicationShutdownEvent event) {
-            CompletableFuture.runAsync({
+            Thread.start {
                 try {
                     Thread.sleep(250)
                     Mono.from(
@@ -402,7 +401,7 @@ class MongoReactiveConfigurationSpec extends Specification {
                 } finally {
                     completed.countDown()
                 }
-            })
+            }
         }
     }
 }

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoReactiveConfigurationSpec.groovy
@@ -26,14 +26,19 @@ import com.mongodb.event.CommandStartedEvent
 import com.mongodb.event.CommandSucceededEvent
 import com.mongodb.event.ConnectionPoolListener
 import com.mongodb.reactivestreams.client.MongoClient
+import com.mongodb.reactivestreams.client.MongoClients
 import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration
 import io.micronaut.configuration.mongo.core.MongoSettings
 import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.qualifiers.Qualifiers
+import io.micronaut.runtime.event.ApplicationShutdownEvent
+import io.micronaut.runtime.event.annotation.EventListener
 import jakarta.inject.Singleton
 import org.bson.BsonReader
 import org.bson.BsonWriter
+import org.bson.Document
 import org.bson.codecs.Codec
 import org.bson.codecs.DecoderContext
 import org.bson.codecs.EncoderContext
@@ -47,6 +52,10 @@ import spock.lang.PendingFeature
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class MongoReactiveConfigurationSpec extends Specification {
 
@@ -289,6 +298,35 @@ class MongoReactiveConfigurationSpec extends Specification {
         "maxSize" | 10
     }
 
+    void "test shutdown delay keeps reactive client available for deferred shutdown work"() {
+        given:
+        String uri = "mongodb://${mongo.getHost()}:${mongo.getMappedPort(27017)}"
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name': 'shutdown-delay-reactive',
+                (MongoSettings.MONGODB_URI): uri,
+                'mongodb.shutdown-delay': '1s',
+                'micronaut.lifecycle.graceful-shutdown.enabled': true,
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '5s'
+        ])
+        ReactiveShutdownListener listener = context.getBean(ReactiveShutdownListener)
+        MongoClient verificationClient = MongoClients.create(uri)
+
+        when:
+        context.stop()
+
+        then:
+        listener.completed.await(5, TimeUnit.SECONDS)
+        listener.error == null
+        Mono.from(
+                verificationClient.getDatabase('shutdown-delay').getCollection('reactive-events')
+                        .countDocuments(new Document('marker', 'reactive'))
+        ).block() == 1
+
+        cleanup:
+        verificationClient?.close()
+        context?.close()
+    }
+
     static class Book {
         String title
     }
@@ -335,5 +373,36 @@ class MongoReactiveConfigurationSpec extends Specification {
 
     @Singleton
     static class FluffConnectionPoolListener implements ConnectionPoolListener {
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'shutdown-delay-reactive')
+    static class ReactiveShutdownListener {
+
+        final MongoClient mongoClient
+        final CountDownLatch completed = new CountDownLatch(1)
+        volatile Throwable error
+
+        ReactiveShutdownListener(MongoClient mongoClient) {
+            this.mongoClient = mongoClient
+        }
+
+        @EventListener
+        void onShutdown(ApplicationShutdownEvent event) {
+            CompletableFuture.runAsync({
+                try {
+                    Thread.sleep(250)
+                    Mono.from(
+                            mongoClient.getDatabase('shutdown-delay')
+                                    .getCollection('reactive-events')
+                                    .insertOne(new Document('marker', 'reactive'))
+                    ).block()
+                } catch (Throwable e) {
+                    error = e
+                } finally {
+                    completed.countDown()
+                }
+            })
+        }
     }
 }

--- a/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/MongoClientShutdownListener.java
+++ b/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/MongoClientShutdownListener.java
@@ -24,7 +24,7 @@ import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
 /**
- * Cleans up tracked blocking Mongo clients when beans are destroyed.
+ * Untracks blocking Mongo clients when beans are destroyed.
  *
  * @author graemerocher
  * @since 6.0.0

--- a/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/MongoClientShutdownListener.java
+++ b/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/MongoClientShutdownListener.java
@@ -15,51 +15,36 @@
  */
 package io.micronaut.configuration.mongo.sync;
 
-import com.mongodb.MongoClientSettings;
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration;
 import io.micronaut.configuration.mongo.core.MongoClientCloser;
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Primary;
 import io.micronaut.context.annotation.Requires;
-
+import io.micronaut.context.event.BeanDestroyedEvent;
+import io.micronaut.context.event.BeanDestroyedEventListener;
+import io.micronaut.core.annotation.Internal;
 import jakarta.inject.Singleton;
 
 /**
- * Builds the primary MongoClient.
+ * Cleans up tracked blocking Mongo clients when beans are destroyed.
  *
  * @author graemerocher
- * @since 1.0
+ * @since 6.0.0
  */
+@Internal
 @Requires(classes = MongoClient.class)
-@Requires(beans = DefaultMongoConfiguration.class)
-@Factory
-public class DefaultMongoClientFactory {
+@Singleton
+final class MongoClientShutdownListener implements BeanDestroyedEventListener<MongoClient> {
 
     private final MongoClientCloser mongoClientCloser;
 
     /**
      * @param mongoClientCloser Tracks configured shutdown delays
      */
-    public DefaultMongoClientFactory(MongoClientCloser mongoClientCloser) {
+    MongoClientShutdownListener(MongoClientCloser mongoClientCloser) {
         this.mongoClientCloser = mongoClientCloser;
     }
 
-    /**
-     * Factory method to return a client.
-     * @param mongoConfiguration configuration pulled in
-     * @param settings settings pulled in
-     * @return mongoClient
-     */
-    @Bean(preDestroy = "close")
-    @Primary
-    @Singleton
-    protected MongoClient mongoClient(DefaultMongoConfiguration mongoConfiguration, MongoClientSettings settings) {
-        return mongoClientCloser.track(
-            MongoClients.create(settings),
-            mongoConfiguration.getShutdownDelay()
-        );
+    @Override
+    public void onDestroyed(BeanDestroyedEvent<MongoClient> event) {
+        mongoClientCloser.untrack(event.getBean());
     }
 }

--- a/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/NamedMongoClientFactory.java
+++ b/mongo-sync/src/main/java/io/micronaut/configuration/mongo/sync/NamedMongoClientFactory.java
@@ -17,6 +17,7 @@ package io.micronaut.configuration.mongo.sync;
 
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
+import io.micronaut.configuration.mongo.core.MongoClientCloser;
 import io.micronaut.configuration.mongo.core.MongoSettings;
 import io.micronaut.configuration.mongo.core.NamedMongoConfiguration;
 import io.micronaut.context.annotation.Bean;
@@ -33,6 +34,15 @@ import io.micronaut.runtime.context.scope.Refreshable;
 @Factory
 public class NamedMongoClientFactory {
 
+    private final MongoClientCloser mongoClientCloser;
+
+    /**
+     * @param mongoClientCloser Tracks configured shutdown delays
+     */
+    public NamedMongoClientFactory(MongoClientCloser mongoClientCloser) {
+        this.mongoClientCloser = mongoClientCloser;
+    }
+
     /**
      * Factory name to create a client.
      * @param configuration configuration pulled in
@@ -42,6 +52,9 @@ public class NamedMongoClientFactory {
     @EachBean(NamedMongoConfiguration.class)
     @Refreshable(MongoSettings.PREFIX)
     MongoClient mongoClient(NamedMongoConfiguration configuration) {
-        return MongoClients.create(configuration.buildSettings());
+        return mongoClientCloser.track(
+            MongoClients.create(configuration.buildSettings()),
+            configuration.getShutdownDelay()
+        );
     }
 }

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
@@ -199,9 +199,9 @@ class MongoConfigurationSpec extends Specification {
         ApplicationContext context = ApplicationContext.run([
                 'spec.name': 'shutdown-delay-sync',
                 (MongoSettings.MONGODB_URI): uri,
-                'mongodb.shutdown-delay': '1s',
+                'mongodb.shutdown-delay': '5s',
                 'micronaut.lifecycle.graceful-shutdown.enabled': true,
-                'micronaut.lifecycle.graceful-shutdown.grace-period': '5s'
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '10s'
         ])
         BlockingShutdownListener listener = context.getBean(BlockingShutdownListener)
         MongoClient verificationClient = MongoClients.create(uri)
@@ -256,7 +256,6 @@ class MongoConfigurationSpec extends Specification {
         void onShutdown(ApplicationShutdownEvent event) {
             Thread.start {
                 try {
-                    Thread.sleep(250)
                     mongoClient.getDatabase('shutdown-delay')
                             .getCollection('sync-events')
                             .insertOne(new Document('marker', 'sync'))

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
@@ -31,8 +31,7 @@ import io.micronaut.configuration.mongo.core.MongoSettings
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.annotation.Requires
 import io.micronaut.core.io.socket.SocketUtils
-import io.micronaut.runtime.event.ApplicationShutdownEvent
-import io.micronaut.runtime.event.annotation.EventListener
+import io.micronaut.runtime.graceful.GracefulShutdownCapable
 import jakarta.inject.Singleton
 import org.bson.Document
 import org.bson.types.ObjectId
@@ -42,6 +41,8 @@ import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CompletionStage
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -242,7 +243,7 @@ class MongoConfigurationSpec extends Specification {
 
     @Singleton
     @Requires(property = 'spec.name', value = 'shutdown-delay-sync')
-    static class BlockingShutdownListener {
+    static class BlockingShutdownListener implements GracefulShutdownCapable {
 
         final MongoClient mongoClient
         final CountDownLatch completed = new CountDownLatch(1)
@@ -252,8 +253,8 @@ class MongoConfigurationSpec extends Specification {
             this.mongoClient = mongoClient
         }
 
-        @EventListener
-        void onShutdown(ApplicationShutdownEvent event) {
+        @Override
+        CompletionStage<?> shutdownGracefully() {
             try {
                 mongoClient.getDatabase('shutdown-delay')
                         .getCollection('sync-events')
@@ -263,6 +264,7 @@ class MongoConfigurationSpec extends Specification {
             } finally {
                 completed.countDown()
             }
+            return CompletableFuture.completedFuture(null)
         }
     }
 }

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
@@ -18,6 +18,7 @@ package io.micronaut.configuration.mongo.sync
 import com.mongodb.MongoClientSettings
 import com.mongodb.ReadConcern
 import com.mongodb.client.MongoClient
+import com.mongodb.client.MongoClients
 import com.mongodb.event.CommandFailedEvent
 import com.mongodb.event.CommandListener
 import com.mongodb.event.CommandStartedEvent
@@ -28,7 +29,10 @@ import io.micronaut.configuration.mongo.LowercaseEnumCodec
 import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration
 import io.micronaut.configuration.mongo.core.MongoSettings
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.runtime.event.ApplicationShutdownEvent
+import io.micronaut.runtime.event.annotation.EventListener
 import jakarta.inject.Singleton
 import org.bson.Document
 import org.bson.types.ObjectId
@@ -37,6 +41,10 @@ import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /**
  * @author graemerocher
@@ -186,6 +194,33 @@ class MongoConfigurationSpec extends Specification {
         context.stop()
     }
 
+    void "test shutdown delay keeps blocking client available for deferred shutdown work"() {
+        given:
+        String uri = "mongodb://${mongo.getHost()}:${mongo.getMappedPort(27017)}"
+        ApplicationContext context = ApplicationContext.run([
+                'spec.name': 'shutdown-delay-sync',
+                (MongoSettings.MONGODB_URI): uri,
+                'mongodb.shutdown-delay': '1s',
+                'micronaut.lifecycle.graceful-shutdown.enabled': true,
+                'micronaut.lifecycle.graceful-shutdown.grace-period': '5s'
+        ])
+        BlockingShutdownListener listener = context.getBean(BlockingShutdownListener)
+        MongoClient verificationClient = MongoClients.create(uri)
+
+        when:
+        context.stop()
+
+        then:
+        listener.completed.await(5, TimeUnit.SECONDS)
+        listener.error == null
+        verificationClient.getDatabase('shutdown-delay').getCollection('sync-events')
+                .countDocuments(new Document('marker', 'sync')) == 1
+
+        cleanup:
+        verificationClient?.close()
+        context?.close()
+    }
+
     @Singleton
     static class FluffCommandListener implements CommandListener {
 
@@ -204,5 +239,34 @@ class MongoConfigurationSpec extends Specification {
 
     @Singleton
     static class FluffConnectionPoolListener implements ConnectionPoolListener {
+    }
+
+    @Singleton
+    @Requires(property = 'spec.name', value = 'shutdown-delay-sync')
+    static class BlockingShutdownListener {
+
+        final MongoClient mongoClient
+        final CountDownLatch completed = new CountDownLatch(1)
+        volatile Throwable error
+
+        BlockingShutdownListener(MongoClient mongoClient) {
+            this.mongoClient = mongoClient
+        }
+
+        @EventListener
+        void onShutdown(ApplicationShutdownEvent event) {
+            CompletableFuture.runAsync({
+                try {
+                    Thread.sleep(250)
+                    mongoClient.getDatabase('shutdown-delay')
+                            .getCollection('sync-events')
+                            .insertOne(new Document('marker', 'sync'))
+                } catch (Throwable e) {
+                    error = e
+                } finally {
+                    completed.countDown()
+                }
+            })
+        }
     }
 }

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
@@ -42,7 +42,6 @@ import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -211,7 +210,7 @@ class MongoConfigurationSpec extends Specification {
         context.stop()
 
         then:
-        listener.completed.await(5, TimeUnit.SECONDS)
+        listener.completed.await(15, TimeUnit.SECONDS)
         listener.error == null
         verificationClient.getDatabase('shutdown-delay').getCollection('sync-events')
                 .countDocuments(new Document('marker', 'sync')) == 1
@@ -255,7 +254,7 @@ class MongoConfigurationSpec extends Specification {
 
         @EventListener
         void onShutdown(ApplicationShutdownEvent event) {
-            CompletableFuture.runAsync({
+            Thread.start {
                 try {
                     Thread.sleep(250)
                     mongoClient.getDatabase('shutdown-delay')
@@ -266,7 +265,7 @@ class MongoConfigurationSpec extends Specification {
                 } finally {
                     completed.countDown()
                 }
-            })
+            }
         }
     }
 }

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoConfigurationSpec.groovy
@@ -254,16 +254,14 @@ class MongoConfigurationSpec extends Specification {
 
         @EventListener
         void onShutdown(ApplicationShutdownEvent event) {
-            Thread.start {
-                try {
-                    mongoClient.getDatabase('shutdown-delay')
-                            .getCollection('sync-events')
-                            .insertOne(new Document('marker', 'sync'))
-                } catch (Throwable e) {
-                    error = e
-                } finally {
-                    completed.countDown()
-                }
+            try {
+                mongoClient.getDatabase('shutdown-delay')
+                        .getCollection('sync-events')
+                        .insertOne(new Document('marker', 'sync'))
+            } catch (Throwable e) {
+                error = e
+            } finally {
+                completed.countDown()
             }
         }
     }

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -28,6 +28,24 @@ mongodb:
         maxSize: 20
 ----
 
+To keep MongoDB clients available briefly for deferred shutdown work triggered by
+api:runtime.event.ApplicationShutdownEvent[] listeners, enable Micronaut graceful
+shutdown and set `mongodb.shutdown-delay`:
+
+[source,yaml]
+----
+micronaut:
+    lifecycle:
+        graceful-shutdown:
+            enabled: true
+            grace-period: 5s
+mongodb:
+    shutdown-delay: 1s
+----
+
+The graceful shutdown grace period must be greater than or equal to
+`mongodb.shutdown-delay`.
+
 ==== Multiple MongoDB Drivers
 
 You can create multiple MongoDB connections using the `mongodb.servers` setting. For example in `application.yml`:

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -35,12 +35,12 @@ shutdown and set `mongodb.shutdown-delay`:
 [source,yaml]
 ----
 micronaut:
-    lifecycle:
-        graceful-shutdown:
-            enabled: true
-            grace-period: 5s
+  lifecycle:
+    graceful-shutdown:
+      enabled: true
+      grace-period: 5s
 mongodb:
-    shutdown-delay: 1s
+  shutdown-delay: 1s
 ----
 
 The graceful shutdown grace period must be greater than or equal to


### PR DESCRIPTION
## Summary
- delay Mongo client destruction via Micronaut graceful shutdown instead of bean pre-destroy hooks
- keep sync and reactive shutdown listener beans internal and package-private
- document that graceful shutdown must be enabled and configured for this feature

Resolves #165