### PR TITLE
Fix Mongo health check for encrypted clients

### DIFF
--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/health/MongoHealthIndicator.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/health/MongoHealthIndicator.java
@@ -101,7 +101,7 @@ public class MongoHealthIndicator implements HealthIndicator {
     }
 
     private Publisher<Document> pingMongo(MongoClient mongoClient) {
-        return mongoClient.getDatabase("admin").runCommand(new BasicDBObject("buildinfo", "1"));
+        return mongoClient.getDatabase("admin").runCommand(new BasicDBObject("buildInfo", "1"));
     }
 
     private Map<String, String> getVersionDetails(Document document) {

--- a/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/health/MongoHealthIndicator.java
+++ b/mongo-reactive/src/main/java/io/micronaut/configuration/mongo/reactive/health/MongoHealthIndicator.java
@@ -15,7 +15,6 @@
  */
 package io.micronaut.configuration.mongo.reactive.health;
 
-import com.mongodb.BasicDBObject;
 import com.mongodb.reactivestreams.client.MongoClient;
 import io.micronaut.context.BeanContext;
 import io.micronaut.context.BeanRegistration;
@@ -101,7 +100,7 @@ public class MongoHealthIndicator implements HealthIndicator {
     }
 
     private Publisher<Document> pingMongo(MongoClient mongoClient) {
-        return mongoClient.getDatabase("admin").runCommand(new BasicDBObject("buildInfo", "1"));
+        return mongoClient.getDatabase("admin").runCommand(new Document("buildInfo", 1));
     }
 
     private Map<String, String> getVersionDetails(Document document) {

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
@@ -16,12 +16,18 @@
 package io.micronaut.configuration.mongo.reactive
 
 import com.mongodb.reactivestreams.client.MongoClient
+import com.mongodb.reactivestreams.client.MongoDatabase
+import io.micronaut.context.BeanContext
+import io.micronaut.context.BeanRegistration
 import io.micronaut.configuration.mongo.reactive.health.MongoHealthIndicator
 import io.micronaut.context.ApplicationContext
 import io.micronaut.context.env.PropertySource
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.core.io.socket.SocketUtils
+import io.micronaut.inject.BeanIdentifier
+import io.micronaut.management.health.aggregator.HealthAggregator
 import io.micronaut.management.health.indicator.HealthResult
+import org.bson.Document
 import org.testcontainers.containers.GenericContainer
 import reactor.core.publisher.Flux
 import spock.lang.Specification
@@ -34,6 +40,30 @@ import static io.micronaut.health.HealthStatus.UP
 import static java.time.temporal.ChronoUnit.SECONDS
 
 class MongoHealthIndicatorSpec extends Specification {
+
+    void "test mongo health indicator uses buildInfo command"() {
+        given:
+        MongoClient mongoClient = Mock()
+        MongoDatabase mongoDatabase = Mock()
+        BeanContext beanContext = Stub() {
+            findBeanRegistration(_ as MongoClient) >> Optional.of(new BeanRegistration<>(BeanIdentifier.of("Primary"), null, mongoClient))
+        }
+        HealthAggregator<?> healthAggregator = Stub() {
+            aggregate(_, _) >> { String name, org.reactivestreams.Publisher<HealthResult> results -> results }
+        }
+        MongoHealthIndicator healthIndicator = new MongoHealthIndicator(beanContext, healthAggregator, mongoClient)
+
+        when:
+        HealthResult healthResult = Flux.from(healthIndicator.result).blockFirst()
+
+        then:
+        1 * mongoClient.getDatabase("admin") >> mongoDatabase
+        1 * mongoDatabase.runCommand({
+            it.get("buildInfo") == "1" && !it.containsField("buildinfo")
+        }) >> Flux.just(new Document("version", "1.2.3"))
+        healthResult.status == UP
+        healthResult.details.version == "1.2.3"
+    }
 
     void "test mongo health indicator disabled"() {
         when:

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
@@ -45,8 +45,12 @@ class MongoHealthIndicatorSpec extends Specification {
         given:
         MongoClient mongoClient = Mock()
         MongoDatabase mongoDatabase = Mock()
+        BeanRegistration<MongoClient> registration = Mock() {
+            getBean() >> mongoClient
+            getIdentifier() >> BeanIdentifier.of("Primary")
+        }
         BeanContext beanContext = Stub() {
-            findBeanRegistration(_ as MongoClient) >> Optional.of(new BeanRegistration<>(BeanIdentifier.of("Primary"), null, mongoClient))
+            findBeanRegistration(_ as MongoClient) >> Optional.of(registration)
         }
         HealthAggregator<?> healthAggregator = Stub() {
             aggregate(_, _) >> { String name, org.reactivestreams.Publisher<HealthResult> results -> results }
@@ -59,7 +63,9 @@ class MongoHealthIndicatorSpec extends Specification {
         then:
         1 * mongoClient.getDatabase("admin") >> mongoDatabase
         1 * mongoDatabase.runCommand({
-            it.get("buildInfo") == "1" && !it.containsField("buildinfo")
+            it.containsKey("buildInfo") &&
+                    (it.get("buildInfo") == "1" || it.get("buildInfo") == 1) &&
+                    !it.containsKey("buildinfo")
         }) >> Flux.just(new Document("version", "1.2.3"))
         healthResult.status == UP
         healthResult.details.version == "1.2.3"

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoHealthIndicatorSpec.groovy
@@ -25,6 +25,7 @@ import io.micronaut.context.env.PropertySource
 import io.micronaut.context.exceptions.NoSuchBeanException
 import io.micronaut.core.io.socket.SocketUtils
 import io.micronaut.inject.BeanIdentifier
+import io.micronaut.inject.BeanDefinition
 import io.micronaut.management.health.aggregator.HealthAggregator
 import io.micronaut.management.health.indicator.HealthResult
 import org.bson.Document
@@ -48,6 +49,7 @@ class MongoHealthIndicatorSpec extends Specification {
         BeanRegistration<MongoClient> registration = Mock() {
             getBean() >> mongoClient
             getIdentifier() >> BeanIdentifier.of("Primary")
+            getBeanDefinition() >> Stub(BeanDefinition)
         }
         BeanContext beanContext = Stub() {
             findBeanRegistration(_ as MongoClient) >> Optional.of(registration)
@@ -64,7 +66,6 @@ class MongoHealthIndicatorSpec extends Specification {
         1 * mongoClient.getDatabase("admin") >> mongoDatabase
         1 * mongoDatabase.runCommand({
             it.containsKey("buildInfo") &&
-                    (it.get("buildInfo") == "1" || it.get("buildInfo") == 1) &&
                     !it.containsKey("buildinfo")
         }) >> Flux.just(new Document("version", "1.2.3"))
         healthResult.status == UP


### PR DESCRIPTION
## Summary
- switch the reactive Mongo health indicator to use the `buildInfo` admin command
- add a regression test that verifies the command name sent by `MongoHealthIndicator`
- keep the change scoped to encrypted-client health check behavior

## Verification
- `./gradlew :micronaut-mongo-reactive:test --tests 'io.micronaut.configuration.mongo.reactive.MongoHealthIndicatorSpec.test mongo health indicator uses buildInfo command' --tests 'io.micronaut.configuration.mongo.reactive.MongoHealthIndicatorSpec.test mongo health indicator disabled' --tests 'io.micronaut.configuration.mongo.reactive.MongoHealthIndicatorSpec.test mongo health indicator DOWN'`
- full `MongoHealthIndicatorSpec` still depends on Docker for the existing `UP` Testcontainers case, which is not available in this environment

Resolves #269