### PR TITLE
Fix @BsonDiscriminator codec registration

### DIFF
--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
@@ -34,6 +34,9 @@ import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -54,6 +57,7 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
 
     private final Environment environment;
     private final BeanProvider<SerdeRegistry> serdeRegistry;
+    private final Map<List<String>, Collection<Class<?>>> discriminatorEntitiesCache = new ConcurrentHashMap<>();
 
     public DefaultCodecRegistryBuilder(Environment environment, BeanProvider<SerdeRegistry> serdeRegistry) {
         this.environment = environment;
@@ -100,10 +104,17 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
     }
 
     private Collection<Class<?>> findDiscriminatorEntities(Collection<String> packageNames) {
-        return BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
-            reference.isPresent()
-                && reference.isAnnotationPresent(BsonDiscriminator.class)
-                && isWithinConfiguredPackages(reference.getBeanType(), packageNames)
+        List<String> packageNamesKey = packageNames.stream()
+            .filter(Objects::nonNull)
+            .distinct()
+            .sorted()
+            .toList();
+        return discriminatorEntitiesCache.computeIfAbsent(packageNamesKey, key ->
+            List.copyOf(BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
+                reference.isPresent()
+                    && reference.isAnnotationPresent(BsonDiscriminator.class)
+                    && isWithinConfiguredPackages(reference.getBeanType(), key)
+            ))
         );
     }
 

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
@@ -104,18 +104,27 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
     }
 
     private Collection<Class<?>> findDiscriminatorEntities(Collection<String> packageNames) {
-        List<String> packageNamesKey = packageNames.stream()
+        List<String> packageNamesKey = normalizePackageNamesForCaching(packageNames);
+        Collection<Class<?>> cachedEntities = discriminatorEntitiesCache.get(packageNamesKey);
+        if (cachedEntities != null) {
+            return cachedEntities;
+        }
+        Collection<Class<?>> discoveredEntities = List.copyOf(BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
+            reference.isPresent()
+                && reference.isAnnotationPresent(BsonDiscriminator.class)
+                && isWithinConfiguredPackages(reference.getBeanType(), packageNamesKey)
+        ));
+        Collection<Class<?>> existingEntities = discriminatorEntitiesCache.putIfAbsent(packageNamesKey, discoveredEntities);
+        return existingEntities != null ? existingEntities : discoveredEntities;
+    }
+
+    private List<String> normalizePackageNamesForCaching(Collection<String> packageNames) {
+        // Normalize order/duplicates so logically equivalent package sets share a single cache key.
+        return packageNames.stream()
             .filter(Objects::nonNull)
             .distinct()
             .sorted()
             .toList();
-        return discriminatorEntitiesCache.computeIfAbsent(packageNamesKey, key ->
-            List.copyOf(BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
-                reference.isPresent()
-                    && reference.isAnnotationPresent(BsonDiscriminator.class)
-                    && isWithinConfiguredPackages(reference.getBeanType(), key)
-            ))
-        );
     }
 
     private boolean isWithinConfiguredPackages(Class<?> beanType, Collection<String> packageNames) {

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultCodecRegistryBuilder.java
@@ -22,12 +22,14 @@ import io.micronaut.context.annotation.Prototype;
 import io.micronaut.context.annotation.Requires;
 import io.micronaut.context.env.Environment;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.beans.BeanIntrospector;
 import io.micronaut.core.util.CollectionUtils;
 import io.micronaut.serde.SerdeRegistry;
 import io.micronaut.serde.annotation.Serdeable;
 import org.bson.codecs.Codec;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -84,14 +86,31 @@ public final class DefaultCodecRegistryBuilder implements CodecRegistryBuilder {
         } else {
             final PojoCodecProvider.Builder builder = PojoCodecProvider.builder();
             if (CollectionUtils.isNotEmpty(packageNames)) {
+                Collection<Class<?>> discriminatorEntities = findDiscriminatorEntities(packageNames);
+                if (CollectionUtils.isNotEmpty(discriminatorEntities)) {
+                    builder.register(discriminatorEntities.toArray(Class<?>[]::new));
+                }
                 builder.register(packageNames.toArray(new String[0]));
             }
-            codecRegistries.add(
-                fromProviders(
-                    builder.automatic(configuration.isAutomaticClassModels()).build()
-                )
-            );
+            codecRegistries.add(fromProviders(
+                builder.automatic(configuration.isAutomaticClassModels()).build()
+            ));
         }
         return fromRegistries(codecRegistries);
+    }
+
+    private Collection<Class<?>> findDiscriminatorEntities(Collection<String> packageNames) {
+        return BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
+            reference.isPresent()
+                && reference.isAnnotationPresent(BsonDiscriminator.class)
+                && isWithinConfiguredPackages(reference.getBeanType(), packageNames)
+        );
+    }
+
+    private boolean isWithinConfiguredPackages(Class<?> beanType, Collection<String> packageNames) {
+        String packageName = beanType.getPackageName();
+        return packageNames.stream().anyMatch(configuredPackage ->
+            packageName.equals(configuredPackage) || packageName.startsWith(configuredPackage + ".")
+        );
     }
 }

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -28,6 +28,20 @@ mongodb:
         maxSize: 20
 ----
 
+==== POJO Discriminators
+
+When using MongoDB POJO codecs together with `@BsonDiscriminator`, configure `mongodb.package-names` so Micronaut can register the matching types with the MongoDB `PojoCodecProvider`.
+
+To avoid classpath or JAR scanning, discriminator registration only considers classes that have Micronaut bean introspections. Annotate the root type and subtypes with `@Introspected`, or otherwise provide bean introspection metadata for those classes.
+
+.Configuring packages for discriminator-based POJOs
+[configuration]
+----
+mongodb:
+  package-names:
+    - example.animals
+----
+
 ==== Multiple MongoDB Drivers
 
 You can create multiple MongoDB connections using the `mongodb.servers` setting. For example in `application.yml`:

--- a/tests/mongo-pojo/src/test/java/example/Animal.java
+++ b/tests/mongo-pojo/src/test/java/example/Animal.java
@@ -1,0 +1,21 @@
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@Introspected
+@BsonDiscriminator(key = "type")
+public class Animal {
+    private String name;
+
+    public Animal() {
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
+++ b/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
@@ -1,0 +1,58 @@
+package example;
+
+import io.micronaut.configuration.mongo.core.DefaultCodecRegistryBuilder;
+import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration;
+import io.micronaut.core.beans.BeanIntrospector;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.runtime.ApplicationConfiguration;
+import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
+import org.bson.BsonString;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+class BsonDiscriminatorTest {
+
+    @Test
+    void decodesCustomDiscriminatorWithoutPrimingSubtypeCodec() {
+        try (ApplicationContext context = ApplicationContext.run()) {
+            DefaultMongoConfiguration configuration = new DefaultMongoConfiguration(
+                new ApplicationConfiguration(),
+                context.getEnvironment()
+            );
+            configuration.setPackageNames(List.of("example"));
+
+            Set<Class<?>> discriminatorEntities = BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
+                    reference.isAnnotationPresent(BsonDiscriminator.class)
+                        && reference.getBeanType().getPackageName().equals("example")
+                ).stream()
+                .collect(Collectors.toSet());
+            Assertions.assertTrue(discriminatorEntities.contains(Animal.class));
+            Assertions.assertTrue(discriminatorEntities.contains(Dog.class));
+
+            CodecRegistry codecRegistry = new DefaultCodecRegistryBuilder(
+                context.getEnvironment(),
+                null
+            ).build(configuration);
+
+            Animal animal = codecRegistry.get(Animal.class).decode(
+                new BsonDocumentReader(new BsonDocument()
+                    .append("type", new BsonString("dog"))
+                    .append("name", new BsonString("Fido"))
+                    .append("favoriteToy", new BsonString("Ball"))),
+                DecoderContext.builder().build()
+            );
+
+            Assertions.assertInstanceOf(Dog.class, animal);
+            Assertions.assertEquals("Fido", animal.getName());
+            Assertions.assertEquals("Ball", ((Dog) animal).getFavoriteToy());
+        }
+    }
+}

--- a/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
+++ b/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 class BsonDiscriminatorTest {
+    private static final String TEST_PACKAGE = "example";
 
     @Test
     void decodesCustomDiscriminatorWithoutPrimingSubtypeCodec() {
@@ -27,13 +28,12 @@ class BsonDiscriminatorTest {
                 new ApplicationConfiguration(),
                 context.getEnvironment()
             );
-            String configuredPackage = "example";
-            configuration.setPackageNames(List.of(configuredPackage));
+            configuration.setPackageNames(List.of(TEST_PACKAGE));
 
             Set<Class<?>> discriminatorEntities = BeanIntrospector.SHARED.findIntrospectedTypes(reference -> {
                     String packageName = reference.getBeanType().getPackageName();
                     return reference.isAnnotationPresent(BsonDiscriminator.class)
-                        && (packageName.equals(configuredPackage) || packageName.startsWith(configuredPackage + "."));
+                        && (packageName.equals(TEST_PACKAGE) || packageName.startsWith(TEST_PACKAGE + "."));
                 }).stream()
                 .collect(Collectors.toSet());
             Assertions.assertTrue(discriminatorEntities.contains(Animal.class));

--- a/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
+++ b/tests/mongo-pojo/src/test/java/example/BsonDiscriminatorTest.java
@@ -27,20 +27,19 @@ class BsonDiscriminatorTest {
                 new ApplicationConfiguration(),
                 context.getEnvironment()
             );
-            configuration.setPackageNames(List.of("example"));
+            String configuredPackage = "example";
+            configuration.setPackageNames(List.of(configuredPackage));
 
-            Set<Class<?>> discriminatorEntities = BeanIntrospector.SHARED.findIntrospectedTypes(reference ->
-                    reference.isAnnotationPresent(BsonDiscriminator.class)
-                        && reference.getBeanType().getPackageName().equals("example")
-                ).stream()
+            Set<Class<?>> discriminatorEntities = BeanIntrospector.SHARED.findIntrospectedTypes(reference -> {
+                    String packageName = reference.getBeanType().getPackageName();
+                    return reference.isAnnotationPresent(BsonDiscriminator.class)
+                        && (packageName.equals(configuredPackage) || packageName.startsWith(configuredPackage + "."));
+                }).stream()
                 .collect(Collectors.toSet());
             Assertions.assertTrue(discriminatorEntities.contains(Animal.class));
             Assertions.assertTrue(discriminatorEntities.contains(Dog.class));
 
-            CodecRegistry codecRegistry = new DefaultCodecRegistryBuilder(
-                context.getEnvironment(),
-                null
-            ).build(configuration);
+            CodecRegistry codecRegistry = context.getBean(DefaultCodecRegistryBuilder.class).build(configuration);
 
             Animal animal = codecRegistry.get(Animal.class).decode(
                 new BsonDocumentReader(new BsonDocument()

--- a/tests/mongo-pojo/src/test/java/example/Dog.java
+++ b/tests/mongo-pojo/src/test/java/example/Dog.java
@@ -1,0 +1,21 @@
+package example;
+
+import io.micronaut.core.annotation.Introspected;
+import org.bson.codecs.pojo.annotations.BsonDiscriminator;
+
+@Introspected
+@BsonDiscriminator(key = "type", value = "dog")
+public class Dog extends Animal {
+    private String favoriteToy;
+
+    public Dog() {
+    }
+
+    public String getFavoriteToy() {
+        return favoriteToy;
+    }
+
+    public void setFavoriteToy(String favoriteToy) {
+        this.favoriteToy = favoriteToy;
+    }
+}


### PR DESCRIPTION
## Summary
- register introspected `@BsonDiscriminator` types with the Pojo codec provider before package registration
- keep discovery limited to Micronaut bean introspections in configured packages
- add a focused regression test for discriminator-based subtype decoding without priming the subtype codec

Resolves #10
