### PR TITLE
Add MongoClientSettings customization support for CSFLE

### DIFF
--- a/docs-examples/csfle-groovy/src/test/groovy/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.groovy
+++ b/docs-examples/csfle-groovy/src/test/groovy/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mongodb.docs
+
+// tag::imports[]
+import com.mongodb.AutoEncryptionSettings
+import com.mongodb.MongoClientSettings
+import io.micronaut.configuration.mongo.core.AbstractMongoConfiguration
+import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomizer
+import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
+import jakarta.inject.Singleton
+import org.bson.UuidRepresentation
+// end::imports[]
+
+// tag::clazz[]
+@Singleton
+class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
+
+    @Override
+    void customize(AbstractMongoConfiguration configuration, MongoClientSettings.Builder clientSettings) {
+        String keyVaultNamespace = configuration instanceof NamedMongoConfiguration
+            ? "encryption.${configuration.serverName}.__keyVault"
+            : 'encryption.__keyVault'
+
+        clientSettings
+            .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                .keyVaultNamespace(keyVaultNamespace)
+                .kmsProviders([local: [key: new byte[96]]] as Map<String, Map<String, Object>>)
+                .build())
+            .uuidRepresentation(UuidRepresentation.STANDARD)
+    }
+}
+// end::clazz[]

--- a/docs-examples/csfle-java/src/test/java/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.java
+++ b/docs-examples/csfle-java/src/test/java/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mongodb.docs;
+
+// tag::imports[]
+import com.mongodb.AutoEncryptionSettings;
+import com.mongodb.MongoClientSettings;
+import io.micronaut.configuration.mongo.core.AbstractMongoConfiguration;
+import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomizer;
+import io.micronaut.configuration.mongo.core.NamedMongoConfiguration;
+import jakarta.inject.Singleton;
+import org.bson.UuidRepresentation;
+
+import java.util.Collections;
+import java.util.Map;
+// end::imports[]
+
+// tag::clazz[]
+@Singleton
+public class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
+
+    @Override
+    public void customize(AbstractMongoConfiguration configuration, MongoClientSettings.Builder clientSettings) {
+        String keyVaultNamespace = "encryption.__keyVault";
+        if (configuration instanceof NamedMongoConfiguration namedMongoConfiguration) {
+            keyVaultNamespace = "encryption." + namedMongoConfiguration.getServerName() + ".__keyVault";
+        }
+
+        Map<String, Map<String, Object>> kmsProviders =
+            Collections.singletonMap("local", Collections.singletonMap("key", new byte[96]));
+
+        clientSettings
+            .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                .keyVaultNamespace(keyVaultNamespace)
+                .kmsProviders(kmsProviders)
+                .build())
+            .uuidRepresentation(UuidRepresentation.STANDARD);
+    }
+}
+// end::clazz[]

--- a/docs-examples/csfle-kotlin/src/test/kotlin/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.kt
+++ b/docs-examples/csfle-kotlin/src/test/kotlin/io/micronaut/mongodb/docs/AutoEncryptionCustomizer.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.mongodb.docs
+
+// tag::imports[]
+import com.mongodb.AutoEncryptionSettings
+import com.mongodb.MongoClientSettings
+import io.micronaut.configuration.mongo.core.AbstractMongoConfiguration
+import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomizer
+import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
+import jakarta.inject.Singleton
+import org.bson.UuidRepresentation
+// end::imports[]
+
+// tag::clazz[]
+@Singleton
+class AutoEncryptionCustomizer : MongoClientSettingsBuilderCustomizer {
+
+    override fun customize(configuration: AbstractMongoConfiguration, clientSettings: MongoClientSettings.Builder) {
+        val keyVaultNamespace = if (configuration is NamedMongoConfiguration) {
+            "encryption.${configuration.serverName}.__keyVault"
+        } else {
+            "encryption.__keyVault"
+        }
+
+        clientSettings
+            .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                .keyVaultNamespace(keyVaultNamespace)
+                .kmsProviders(mapOf("local" to mapOf("key" to ByteArray(96))))
+                .build())
+            .uuidRepresentation(UuidRepresentation.STANDARD)
+    }
+}
+// end::clazz[]

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/AbstractMongoConfiguration.java
@@ -51,6 +51,7 @@ public abstract class AbstractMongoConfiguration {
     private List<CodecRegistry> codecRegistries = Collections.emptyList();
     private List<CommandListener> commandListeners = Collections.emptyList();
     private List<ConnectionPoolListener> connectionPoolListeners = Collections.emptyList();
+    private List<MongoClientSettingsBuilderCustomizer> clientSettingsBuilderCustomizers = Collections.emptyList();
     private Collection<String> packageNames;
     private boolean automaticClassModels = true;
     private CodecRegistryBuilder codecRegistryBuilder;
@@ -105,6 +106,17 @@ public abstract class AbstractMongoConfiguration {
     public void connectionPoolListeners(List<ConnectionPoolListener> connectionPoolListeners) {
         if (connectionPoolListeners != null) {
             this.connectionPoolListeners = connectionPoolListeners;
+        }
+    }
+
+    /**
+     * Additional customizers to apply to the client settings builder.
+     *
+     * @param clientSettingsBuilderCustomizers The customizers
+     */
+    public void clientSettingsBuilderCustomizers(List<MongoClientSettingsBuilderCustomizer> clientSettingsBuilderCustomizers) {
+        if (clientSettingsBuilderCustomizers != null) {
+            this.clientSettingsBuilderCustomizers = clientSettingsBuilderCustomizers;
         }
     }
 
@@ -271,6 +283,7 @@ public abstract class AbstractMongoConfiguration {
         clientSettings.applyToSslSettings(builder -> builder.applySettings(sslSettings.build()));
         clientSettings.codecRegistry(codecRegistryBuilder.build(this));
         clientSettings.commandListenerList(commandListeners);
+        clientSettingsBuilderCustomizers.forEach(customizer -> customizer.customize(this, clientSettings));
         return clientSettings.build();
     }
 

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultMongoConfiguration.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/DefaultMongoConfiguration.java
@@ -115,6 +115,12 @@ public class DefaultMongoConfiguration extends AbstractMongoConfiguration {
         super.connectionPoolListeners(connectionPoolListeners);
     }
 
+    @Override
+    @Inject
+    public void clientSettingsBuilderCustomizers(List<MongoClientSettingsBuilderCustomizer> clientSettingsBuilderCustomizers) {
+        super.clientSettingsBuilderCustomizers(clientSettingsBuilderCustomizers);
+    }
+
     /**
      * Sets the server MongoDB server address.
      *

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientSettingsBuilderCustomizer.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/MongoClientSettingsBuilderCustomizer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.core;
+
+import com.mongodb.MongoClientSettings;
+
+/**
+ * Allows arbitrary customization of the {@link MongoClientSettings.Builder}
+ * after Micronaut has applied the configuration-backed settings and before
+ * the final {@link MongoClientSettings} is built.
+ *
+ * @author graemerocher
+ * @since 6.0.0
+ */
+@FunctionalInterface
+public interface MongoClientSettingsBuilderCustomizer {
+
+    /**
+     * Customize the builder for the given configuration.
+     *
+     * @param configuration The configuration being built
+     * @param clientSettings The settings builder
+     */
+    void customize(AbstractMongoConfiguration configuration, MongoClientSettings.Builder clientSettings);
+}

--- a/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/NamedMongoConfiguration.java
+++ b/mongo-core/src/main/java/io/micronaut/configuration/mongo/core/NamedMongoConfiguration.java
@@ -118,6 +118,12 @@ public class NamedMongoConfiguration extends AbstractMongoConfiguration {
         super.connectionPoolListeners(connectionPoolListeners);
     }
 
+    @Override
+    @Inject
+    public void clientSettingsBuilderCustomizers(List<MongoClientSettingsBuilderCustomizer> clientSettingsBuilderCustomizers) {
+        super.clientSettingsBuilderCustomizers(clientSettingsBuilderCustomizers);
+    }
+
     /**
      * @return The name of the server
      */

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -42,12 +42,13 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         )
 
         DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
+        MongoClientSettings settings = configuration.buildSettings()
         MongoClient mongoClient = context.getBean(MongoClient)
 
         expect:
         mongoClient != null
-        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
-        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+        settings.autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
+        settings.uuidRepresentation == UuidRepresentation.STANDARD
 
         cleanup:
         context.stop()
@@ -62,12 +63,13 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         )
 
         NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
+        MongoClientSettings settings = configuration.buildSettings()
         MongoClient mongoClient = context.getBean(MongoClient, Qualifiers.byName('my-server'))
 
         expect:
         mongoClient != null
-        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
-        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+        settings.autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
+        settings.uuidRepresentation == UuidRepresentation.STANDARD
 
         cleanup:
         context.stop()

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -24,18 +24,21 @@ import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomize
 import io.micronaut.configuration.mongo.core.MongoSettings
 import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.qualifiers.Qualifiers
 import jakarta.inject.Singleton
 import org.bson.UuidRepresentation
 import spock.lang.Specification
 
 class MongoClientSettingsBuilderCustomizerSpec extends Specification {
+    private static final String SPEC_NAME = 'mongo-client-settings-builder-customizer-reactive'
 
     void "test configure picks up custom MongoClientSettings builder customizers for default reactive client"() {
         given:
         ApplicationContext context = ApplicationContext.run(
                 (MongoSettings.EMBEDDED): false,
-                (MongoSettings.MONGODB_URI): "mongodb://localhost"
+                (MongoSettings.MONGODB_URI): "mongodb://localhost",
+                'spec.name': SPEC_NAME
         )
 
         DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
@@ -54,7 +57,8 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run(
                 (MongoSettings.EMBEDDED): false,
-                'mongodb.servers.myServer.uri': "mongodb://localhost:27017"
+                'mongodb.servers.myServer.uri': "mongodb://localhost:27017",
+                'spec.name': SPEC_NAME
         )
 
         NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
@@ -69,6 +73,7 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         context.stop()
     }
 
+    @Requires(property = 'spec.name', value = SPEC_NAME)
     @Singleton
     static class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
 

--- a/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-reactive/src/test/groovy/io/micronaut/configuration/mongo/reactive/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.reactive
+
+import com.mongodb.AutoEncryptionSettings
+import com.mongodb.MongoClientSettings
+import com.mongodb.reactivestreams.client.MongoClient
+import io.micronaut.configuration.mongo.core.AbstractMongoConfiguration
+import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration
+import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomizer
+import io.micronaut.configuration.mongo.core.MongoSettings
+import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.inject.Singleton
+import org.bson.UuidRepresentation
+import spock.lang.Specification
+
+class MongoClientSettingsBuilderCustomizerSpec extends Specification {
+
+    void "test configure picks up custom MongoClientSettings builder customizers for default reactive client"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                (MongoSettings.EMBEDDED): false,
+                (MongoSettings.MONGODB_URI): "mongodb://localhost"
+        )
+
+        DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
+        MongoClient mongoClient = context.getBean(MongoClient)
+
+        expect:
+        mongoClient != null
+        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
+        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+
+        cleanup:
+        context.stop()
+    }
+
+    void "test configure picks up custom MongoClientSettings builder customizers for named reactive client"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                (MongoSettings.EMBEDDED): false,
+                'mongodb.servers.myServer.uri': "mongodb://localhost:27017"
+        )
+
+        NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
+        MongoClient mongoClient = context.getBean(MongoClient, Qualifiers.byName('my-server'))
+
+        expect:
+        mongoClient != null
+        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
+        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+
+        cleanup:
+        context.stop()
+    }
+
+    @Singleton
+    static class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
+
+        @Override
+        void customize(AbstractMongoConfiguration configuration, MongoClientSettings.Builder clientSettings) {
+            String keyVaultNamespace = configuration instanceof NamedMongoConfiguration
+                    ? "encryption.${configuration.serverName}.__keyVault"
+                    : "encryption.__keyVault"
+            clientSettings
+                    .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                            .keyVaultNamespace(keyVaultNamespace)
+                            .kmsProviders([local: [key: new byte[96]]] as Map<String, Map<String, Object>>)
+                            .build())
+                    .uuidRepresentation(UuidRepresentation.STANDARD)
+        }
+    }
+}

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017-2022 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.configuration.mongo.sync
+
+import com.mongodb.AutoEncryptionSettings
+import com.mongodb.MongoClientSettings
+import io.micronaut.configuration.mongo.core.AbstractMongoConfiguration
+import io.micronaut.configuration.mongo.core.DefaultMongoConfiguration
+import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomizer
+import io.micronaut.configuration.mongo.core.MongoSettings
+import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
+import io.micronaut.context.ApplicationContext
+import io.micronaut.inject.qualifiers.Qualifiers
+import jakarta.inject.Singleton
+import org.bson.UuidRepresentation
+import spock.lang.Specification
+
+class MongoClientSettingsBuilderCustomizerSpec extends Specification {
+
+    void "test configure picks up custom MongoClientSettings builder customizers for default client"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                (MongoSettings.EMBEDDED): false,
+                (MongoSettings.MONGODB_URI): "mongodb://localhost"
+        )
+
+        DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
+        MongoClientSettings settings = context.getBean(MongoClientSettings)
+
+        expect:
+        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
+        settings.autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
+        settings.uuidRepresentation == UuidRepresentation.STANDARD
+
+        cleanup:
+        context.stop()
+    }
+
+    void "test configure picks up custom MongoClientSettings builder customizers for named client"() {
+        given:
+        ApplicationContext context = ApplicationContext.run(
+                (MongoSettings.EMBEDDED): false,
+                'mongodb.servers.myServer.uri': "mongodb://localhost:27017"
+        )
+
+        NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
+
+        expect:
+        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
+        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+
+        cleanup:
+        context.stop()
+    }
+
+    @Singleton
+    static class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
+
+        @Override
+        void customize(AbstractMongoConfiguration configuration, MongoClientSettings.Builder clientSettings) {
+            String keyVaultNamespace = configuration instanceof NamedMongoConfiguration
+                    ? "encryption.${configuration.serverName}.__keyVault"
+                    : "encryption.__keyVault"
+            clientSettings
+                    .autoEncryptionSettings(AutoEncryptionSettings.builder()
+                            .keyVaultNamespace(keyVaultNamespace)
+                            .kmsProviders([local: [key: new byte[96]]] as Map<String, Map<String, Object>>)
+                            .build())
+                    .uuidRepresentation(UuidRepresentation.STANDARD)
+        }
+    }
+}

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -41,10 +41,11 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         )
 
         DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
+        MongoClientSettings builtSettings = configuration.buildSettings()
         MongoClientSettings settings = context.getBean(MongoClientSettings)
 
         expect:
-        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
+        builtSettings.autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
         settings.autoEncryptionSettings.keyVaultNamespace == "encryption.__keyVault"
         settings.uuidRepresentation == UuidRepresentation.STANDARD
 
@@ -61,10 +62,11 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         )
 
         NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
+        MongoClientSettings settings = configuration.buildSettings()
 
         expect:
-        configuration.buildSettings().autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
-        configuration.buildSettings().uuidRepresentation == UuidRepresentation.STANDARD
+        settings.autoEncryptionSettings.keyVaultNamespace == "encryption.my-server.__keyVault"
+        settings.uuidRepresentation == UuidRepresentation.STANDARD
 
         cleanup:
         context.stop()

--- a/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
+++ b/mongo-sync/src/test/groovy/io/micronaut/configuration/mongo/sync/MongoClientSettingsBuilderCustomizerSpec.groovy
@@ -23,18 +23,21 @@ import io.micronaut.configuration.mongo.core.MongoClientSettingsBuilderCustomize
 import io.micronaut.configuration.mongo.core.MongoSettings
 import io.micronaut.configuration.mongo.core.NamedMongoConfiguration
 import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.Requires
 import io.micronaut.inject.qualifiers.Qualifiers
 import jakarta.inject.Singleton
 import org.bson.UuidRepresentation
 import spock.lang.Specification
 
 class MongoClientSettingsBuilderCustomizerSpec extends Specification {
+    private static final String SPEC_NAME = 'mongo-client-settings-builder-customizer-sync'
 
     void "test configure picks up custom MongoClientSettings builder customizers for default client"() {
         given:
         ApplicationContext context = ApplicationContext.run(
                 (MongoSettings.EMBEDDED): false,
-                (MongoSettings.MONGODB_URI): "mongodb://localhost"
+                (MongoSettings.MONGODB_URI): "mongodb://localhost",
+                'spec.name': SPEC_NAME
         )
 
         DefaultMongoConfiguration configuration = context.getBean(DefaultMongoConfiguration)
@@ -53,7 +56,8 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         given:
         ApplicationContext context = ApplicationContext.run(
                 (MongoSettings.EMBEDDED): false,
-                'mongodb.servers.myServer.uri': "mongodb://localhost:27017"
+                'mongodb.servers.myServer.uri': "mongodb://localhost:27017",
+                'spec.name': SPEC_NAME
         )
 
         NamedMongoConfiguration configuration = context.getBean(NamedMongoConfiguration, Qualifiers.byName('my-server'))
@@ -66,6 +70,7 @@ class MongoClientSettingsBuilderCustomizerSpec extends Specification {
         context.stop()
     }
 
+    @Requires(property = 'spec.name', value = SPEC_NAME)
     @Singleton
     static class AutoEncryptionCustomizer implements MongoClientSettingsBuilderCustomizer {
 

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -30,7 +30,7 @@ Use the approach as follows:
 4. Populate the builder with the KMS providers, key vault namespace, schema map, encrypted fields map, and any extra auto-encryption options required by your deployment.
 
 .Customizing `MongoClientSettings.Builder` for CSFLE
-snippet::io.micronaut.mongodb.docs.AutoEncryptionCustomizer[tags="imports,clazz", project-base="docs-examples/csfle"]
+snippet::io.micronaut.mongodb.docs.AutoEncryptionCustomizer[tags="imports,clazz", project-base="docs-examples/csfle-java"]
 
 The example uses the local KMS provider for brevity. Replace that placeholder with the provider configuration that matches your environment.
 

--- a/src/main/docs/guide/config.adoc
+++ b/src/main/docs/guide/config.adoc
@@ -1,31 +1,50 @@
-The configuration options for the blocking client and the non-blocking client differ at the driver level.
+Micronaut binds MongoDB driver settings directly onto `MongoClientSettings.Builder` and the nested builder types it exposes, such as `cluster`, `connectionPool`, `socket`, `server`, and `ssl`.
 
-To configure the blocking client options you can use the `mongodb.options` setting which allows you to configure any property of the `MongoClientOptions.Builder` class. For example in `application.yml`:
+For example, in `application.yml`:
 
-.Configuring Blocking Driver Options
+.Configuring MongoDB Driver Settings
 [source,yaml]
 ----
 mongodb:
-    ...
-    options:
-        maxConnectionIdleTime: 10000
-        readConcern: majority
+    uri: mongodb://localhost:27017/app
+    readConcern: majority
+    connectionPool:
+        maxSize: 20
 ----
 
-See the API for api:configuration.mongo.reactive.DefaultMongoConfiguration[] for more information on the available configuration options.
+The same configuration model is used for both the blocking and reactive clients. Named clients use the same structure under `mongodb.servers.<name>`.
 
-For the Reactive driver, the api:configuration.mongo.reactive.DefaultReactiveMongoConfiguration[] exposes options to configure the Reactive Streams driver. For example:
+See the API for api:configuration.mongo.core.DefaultMongoConfiguration[] and api:configuration.mongo.core.NamedMongoConfiguration[] for more information on the available configuration options.
 
+==== CSFLE and Other Programmatic Settings
+
+Some MongoDB features, including Client-Side Field Level Encryption (CSFLE), require programmatic customization that cannot be expressed as simple configuration properties. For those cases, define one or more api:configuration.mongo.core.MongoClientSettingsBuilderCustomizer[] beans.
+
+Micronaut applies these customizers after the configuration-backed settings have been bound and before the final `MongoClientSettings` instance is built. That lets you keep the common driver configuration in `application.yml` and add CSFLE-specific settings only where the MongoDB Java driver requires programmatic setup.
+
+Use the approach as follows:
+
+1. Configure the common driver settings such as `mongodb.uri`, `readConcern`, and pool options in configuration properties.
+2. Add a `MongoClientSettingsBuilderCustomizer` bean for the driver-level settings that are not exposed as simple properties, such as `AutoEncryptionSettings` and `uuidRepresentation`.
+3. Inspect api:configuration.mongo.core.NamedMongoConfiguration[] inside the customizer when the CSFLE settings need to vary per named client.
+4. Populate the builder with the KMS providers, key vault namespace, schema map, encrypted fields map, and any extra auto-encryption options required by your deployment.
+
+.Customizing `MongoClientSettings.Builder` for CSFLE
+snippet::io.micronaut.mongodb.docs.AutoEncryptionCustomizer[tags="imports,clazz", project-base="docs-examples/csfle"]
+
+The example uses the local KMS provider for brevity. Replace that placeholder with the provider configuration that matches your environment.
+
+The same customizer beans apply to both the blocking and reactive drivers because both clients are created from the same `AbstractMongoConfiguration.buildSettings()` workflow.
+
+For the Reactive driver, the same configuration properties apply. For example:
 
 .Configuring the Reactive Streams Driver
 [source,yaml]
 ----
 mongodb:
-    ...
+    uri: mongodb://localhost:27017/app
     cluster:
         maxWaitQueueSize: 5
-    connectionPool:
-        maxSize: 20
 ----
 
 ==== Multiple MongoDB Drivers


### PR DESCRIPTION
## Summary
- add a `MongoClientSettingsBuilderCustomizer` hook for default and named MongoDB configurations
- cover sync and reactive clients with focused regression specs
- document the CSFLE approach with snippet-backed Java, Groovy, and Kotlin examples

## Verification
- `./gradlew --rerun-tasks :micronaut-mongo-sync:test --tests 'io.micronaut.configuration.mongo.sync.MongoClientSettingsBuilderCustomizerSpec' :micronaut-mongo-reactive:test --tests 'io.micronaut.configuration.mongo.reactive.MongoClientSettingsBuilderCustomizerSpec'`\n- `./gradlew :micronaut-mongo-sync:test --tests 'io.micronaut.configuration.mongo.sync.MongoClientSettingsBuilderCustomizerSpec' :micronaut-mongo-reactive:test --tests 'io.micronaut.configuration.mongo.reactive.MongoClientSettingsBuilderCustomizerSpec' docs`\n- `./gradlew publishGuide`\n\nResolves #471