### PR TITLE
Sync CI workflows from the project template

### DIFF
--- a/.github/workflows/graalvm-latest.yml
+++ b/.github/workflows/graalvm-latest.yml
@@ -4,27 +4,18 @@
 #
 # and edit them there. Note that it will be sync'ed to all the Micronaut repos
 name: GraalVM Latest CI
+# Called by Java CI (gradle.yml) once its build job passes and the Sonar quality gate did not
+# fail. The caller's triggers, draft check and concurrency group cover this workflow, so it
+# declares no concurrency of its own; reusing the caller's group expression here would make
+# the called jobs wait on, or cancel, their own run.
 on:
-  push:
-    branches:
-      - master
-      - main
-      - '[0-9]+.[0-9]+.x'
-  pull_request:
-    branches:
-      - master
-      - main
-      - '[0-9]+.[0-9]+.x'
-    types: [opened, synchronize, reopened, ready_for_review]
-# A new push to a pull request cancels its older run, freeing the shared runner
-# pool. Pushes to branches get a group of their own and are never cancelled.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  workflow_call:
 jobs:
   build_matrix:
     if: github.repository != 'micronaut-projects/micronaut-project-template' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_cachePush: ${{ github.event_name == 'push' }}
     outputs:
       matrix: ${{ steps.build-matrix.outputs.matrix }}
     steps:
@@ -34,14 +25,14 @@ jobs:
         id: build-matrix
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         with:
           java-version: '25'
   build:
     needs: build_matrix
     if: github.repository != 'micronaut-projects/micronaut-project-template'
     runs-on: ubuntu-latest
+    env:
+      ORG_GRADLE_PROJECT_cachePush: ${{ github.event_name == 'push' }}
     strategy:
       max-parallel: 6
       matrix:
@@ -59,8 +50,6 @@ jobs:
         id: pre-build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         with:
           distribution: 'graalvm'
           gradle-java: '25'
@@ -71,8 +60,6 @@ jobs:
         id: build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
           GRAALVM_QUICK_BUILD: true
@@ -84,7 +71,5 @@ jobs:
         id: post-build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
         with:
           java: ${{ matrix.java }}

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,9 +30,16 @@ jobs:
     strategy:
       matrix:
         java: ['25']
+    outputs:
+      # Outcome of the static analysis step: success, failure or skipped (no Sonar token, e.g. fork pull requests)
+      sonar: ${{ steps.sonar.outcome }}
     env:
       TESTCONTAINERS_RYUK_DISABLED: true
       SONAR_TOKEN_AVAILABLE: ${{ secrets.SONAR_TOKEN != '' }}
+      # Branch pushes write to the remote build cache so later jobs and pull requests reuse
+      # their outputs; pull requests only read. Set explicitly: the setup-gradle token makes the
+      # micronaut-build settings plugin detect CI on every build, which would otherwise push.
+      ORG_GRADLE_PROJECT_cachePush: ${{ github.event_name == 'push' }}
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Remove system JDKs
@@ -65,6 +72,15 @@ jobs:
 
       - name: "🔧 Setup Gradle"
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6
+        with:
+          # Exchanged for a short-lived token that the following steps receive as DEVELOCITY_ACCESS_KEY and
+          # GRADLE_ENTERPRISE_ACCESS_KEY, so the long-lived key never reaches the build. Pushes use the writer key.
+          # Other events use DEVELOCITY_PULL_REQUEST_ACCESS_KEY, a key whose Develocity user cannot write to the
+          # build cache, and fall back to the writer key until that secret exists.
+          develocity-access-key: >-
+            ${{ (github.event_name == 'push' && secrets.GRADLE_ENTERPRISE_ACCESS_KEY) ||
+                (github.event_name != 'push' && (secrets.DEVELOCITY_PULL_REQUEST_ACCESS_KEY || secrets.GRADLE_ENTERPRISE_ACCESS_KEY)) ||
+                '' }}
 
       - name: "❓ Optional setup step"
         run: |
@@ -73,23 +89,21 @@ jobs:
       - name: "🛠 Build with Gradle"
         id: gradle
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           GH_TOKEN_PUBLIC_REPOS_READONLY: ${{ secrets.GH_TOKEN_PUBLIC_REPOS_READONLY }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
         run: |
           ./gradlew check jacocoReport --no-daemon --continue
 
       - name: "🔎 Run static analysis"
+        id: sonar
         if: env.SONAR_TOKEN_AVAILABLE == 'true' && matrix.java == '25'
+        # Waits for the quality gate so a failing gate stops the native tests, but does not fail this
+        # job: snapshot and docs publishing below keep running on branch pushes.
+        continue-on-error: true
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          ./gradlew sonar --no-parallel --continue
+          ./gradlew sonar --no-parallel --continue -Dsonar.qualitygate.wait=true
 
       - name: "📊 Publish Test Report"
         if: always()
@@ -109,9 +123,6 @@ jobs:
       - name: "📦 Publish to Sonatype Snapshots"
         if: success() && github.event_name == 'push' && matrix.java == '25'
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_CACHE_USERNAME: ${{ secrets.GRADLE_ENTERPRISE_CACHE_USERNAME }}
-          DEVELOCITY_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
         run: ./gradlew publishToSonatype docs --no-daemon
@@ -136,3 +147,10 @@ jobs:
       - name: "❓ Optional cleanup step"
         run: |
           [ -f ./cleanup.sh ] && ./cleanup.sh || [ ! -f ./cleanup.sh ]
+  # Native tests start only when the build and its tests passed and the Sonar quality gate did not
+  # fail, so a red or cancelled build never takes runners for the native matrix.
+  native:
+    needs: build
+    if: needs.build.outputs.sonar != 'failure'
+    uses: ./.github/workflows/graalvm-latest.yml
+    secrets: inherit


### PR DESCRIPTION
Manual sync of `.github/workflows` from [micronaut-project-template](https://github.com/micronaut-projects/micronaut-project-template).

### What changes

- Whatever the template's workflows have gained since the last sync — see the diff. Any project-specific workflow in this repository that runs on `pull_request` gets the template's draft skip, `ready_for_review` trigger and concurrency group as well.

### Verification

This PR is opened as a draft on purpose: with the template workflows in place, no CI runs while it is a draft, so it does not occupy the shared runner pool. Mark it ready for review to run CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
